### PR TITLE
Implement package publishing to github package registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,12 @@ jobs:
         name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - # https://github.com/docker/login-action
-        name: Log in to the Container registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          # Maybe there is a default env var for this?
-          registry: git.maronato.dev
-          username: ${{ github.repository_owner }}}
-          # Ideally, we should only need to set "permissions: package: write", but
-          # Gitea is having issues with that. For now, this is a manually created
-          # token available user-wise, with the "package:write" permission.
-          password: ${{ secrets.PACKAGE_WRITE_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - # https://github.com/docker/metadata-action
         # Generate tags and labels for the image
         # according to the commit and the branch
@@ -43,9 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          # The container image name needs the custom registry in it.
-          # Maybe there is a default env var for this?
-          images: git.maronato.dev/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 # Controls when the workflow will run
 on:
+  workflow_dispatch:
   release:
     types:
       - published


### PR DESCRIPTION
This was introduced because main package registry is not available at the moment.

Addressing the next issue:
- https://github.com/Maronato/go-finger/issues/1