### PR TITLE
Update Docker registry login in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,12 @@ jobs:
         name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - # https://github.com/docker/login-action
-        name: Log in to the Container registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          # Maybe there is a default env var for this?
-          registry: git.maronato.dev
-          username: ${{ github.repository_owner }}}
-          # Ideally, we should only need to set "permissions: package: write", but
-          # Gitea is having issues with that. For now, this is a manually created
-          # token available user-wise, with the "package:write" permission.
-          password: ${{ secrets.PACKAGE_WRITE_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - # https://github.com/docker/metadata-action
         # Generate tags and labels for the image
         # according to the commit and the branch
@@ -43,9 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          # The container image name needs the custom registry in it.
-          # Maybe there is a default env var for this?
-          images: git.maronato.dev/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 # Controls when the workflow will run
 on:
+  workflow_dispatch:
   release:
     types:
       - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
       - # https://github.com/actions/cache
         name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/maronato/go-finger
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,16 @@ jobs:
     steps:
       - # Get the repository's code
         name: Checkout
-        uses: actions/checkout@v2
-      - # https://github.com/vegardit/docker-gitea-act-runner/issues/23
-        name: Fix docker sock permissions
-        run: sudo chmod 666 /var/run/docker.sock
+        uses: actions/checkout@v4
       - # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - # https://github.com/docker/setup-buildx-action
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -37,7 +34,7 @@ jobs:
         # according to the commit and the branch
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -45,20 +42,17 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - # httos://github.com/actions/cache
+      - # https://github.com/actions/cache
         name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: |
-            /go/pkg/mod/
-            /tmp/.go-build-cache
-            /tmp/.buildx-cache
+          path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - # https://github.com/docker/build-push-action
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,11 @@ COPY urns.yml /app/urns.yml
 # Set our runtime environment
 ENV ENV_DOCKER=true
 
-COPY --from=builder /go/src/app/finger /usr/local/bin/finger
+COPY --from=builder /go/src/app/go-finger /usr/local/bin/go-finger
 
-HEALTHCHECK CMD [ "finger", "healthcheck" ]
+HEALTHCHECK CMD [ "go-finger", "healthcheck" ]
 
 EXPOSE 8080
 
-ENTRYPOINT [ "finger" ]
+ENTRYPOINT [ "go-finger" ]
 CMD [ "serve" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY_NAME=finger
+BINARY_NAME=go-finger
 VERSION=$(shell git describe --tags --abbrev=0 || echo "undefined")
 
 all: lint build test

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Webfinger handler / standalone server written in Go.
 To use Finger in your existing server, download the package as a dependency:
 
 ```bash
-go get git.maronato.dev/maronato/finger@latest
+go get github.com/Maronato/go-finger@latest
 ```
 
 Then, use it as a regular `http.Handler`:
@@ -25,8 +25,8 @@ import (
 	"log"
 	"net/http"
 
-	"git.maronato.dev/maronato/finger/handler"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/handler"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func main() {
@@ -64,7 +64,7 @@ If you don't have a server, Finger can also serve itself. You can install it via
 Via `go install`:
 
 ```bash
-go install git.maronato.dev/maronato/finger@latest
+go install github.com/Maronato/go-finger@latest
 ```
 
 Via Docker:
@@ -74,7 +74,7 @@ docker run \
     --name finger \
     -p 8080:8080 \
     -v ${PWD}/fingers.yml:/app/fingers.yml \
-    git.maronato.dev/maronato/finger
+    ghcr.io/maronato/go-finger
 ```
 
 ## Usage
@@ -211,10 +211,10 @@ If you're using the Docker image, you can mount your `fingers.yml` file to `/app
 To run the docker image with flags or a different command, specify the command followed by the flags:
 ```bash
 # Start the server on port 3030 in debug mode with a different fingers file
-docker run git.maronato.dev/maronato/finger serve --port 3030 --debug --finger-file /app/my-fingers.yml
+docker run ghcr.io/maronato/go-finger serve --port 3030 --debug --finger-file /app/my-fingers.yml
 
 # or run a healthcheck on a different finger container
-docker run git.maronato.dev/maronato/finger healthcheck --host otherhost --port 3030
+docker run ghcr.io/maronato/go-finger healthcheck --host otherhost --port 3030
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker run \
 
 If you installed it using `go install`, run
 ```bash
-finger serve
+go-finger serve
 ```
 To start the server on port `8080`. Your resources will be queryable via `locahost:8080/.well-known/webfinger?resource=<your-resource>`
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you installed it using `go install`, run
 ```bash
 go-finger serve
 ```
-To start the server on port `8080`. Your resources will be queryable via `locahost:8080/.well-known/webfinger?resource=<your-resource>`
+To start the server on port `8080`. Your resources will be queryable via `localhost:8080/.well-known/webfinger?resource=<your-resource>`
 
 If you're using Docker, the use the same command in the install section.
 
@@ -221,7 +221,7 @@ docker run ghcr.io/maronato/go-finger healthcheck --host otherhost --port 3030
 
 You need to have [Go](https://golang.org/) installed to build the project.
 
-Clone the repo and run `make build` to build the binary. You can then run `./finger serve` to start the server.
+Clone the repo and run `make build` to build the binary. You can then run `./go-finger serve` to start the server.
 
 A few other commands are:
  - `make run` to run the server

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"git.maronato.dev/maronato/finger/internal/config"
+	"github.com/Maronato/go-finger/internal/config"
 	"github.com/peterbourgon/ff/v4"
 	"github.com/peterbourgon/ff/v4/ffhelp"
 )

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"git.maronato.dev/maronato/finger/internal/config"
+	"github.com/Maronato/go-finger/internal/config"
 	"github.com/peterbourgon/ff/v4"
 )
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/Maronato/go-finger/internal/config"
 	"github.com/Maronato/go-finger/internal/fingerreader"
@@ -13,7 +12,7 @@ import (
 	"github.com/peterbourgon/ff/v4"
 )
 
-var appName = filepath.Base(os.Args[0])
+const appName = "go-finger"
 
 func newServerCmd(cfg *config.Config) *ff.Command {
 	return &ff.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/fingerreader"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/server"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/fingerreader"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/server"
 	"github.com/peterbourgon/ff/v4"
 )
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Maronato/go-finger/internal/config"
 	"github.com/Maronato/go-finger/internal/fingerreader"
@@ -12,7 +13,7 @@ import (
 	"github.com/peterbourgon/ff/v4"
 )
 
-const appName = "finger"
+var appName = filepath.Base(os.Args[0])
 
 func newServerCmd(cfg *config.Config) *ff.Command {
 	return &ff.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.maronato.dev/maronato/finger
+module github.com/Maronato/go-finger
 
 go 1.21.0
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func WebfingerHandler(fingers webfingers.WebFingers) http.Handler {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/handler"
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/handler"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func TestWebfingerHandler(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
+	"github.com/Maronato/go-finger/internal/config"
 )
 
 func TestConfig_GetAddr(t *testing.T) {

--- a/internal/fingerreader/fingerreader.go
+++ b/internal/fingerreader/fingerreader.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"os"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/webfingers"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/fingerreader/fingerreader_test.go
+++ b/internal/fingerreader/fingerreader_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/fingerreader"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/fingerreader"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func newTempFile(t *testing.T, content string) (name string, remove func()) {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log/slog"
 
-	"git.maronato.dev/maronato/finger/internal/config"
+	"github.com/Maronato/go-finger/internal/config"
 )
 
 type loggerCtxKey struct{}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
 )
 
 func assertPanic(t *testing.T, f func()) {

--- a/internal/middleware/log.go
+++ b/internal/middleware/log.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"git.maronato.dev/maronato/finger/internal/log"
+	"github.com/Maronato/go-finger/internal/log"
 )
 
 func RequestLogger(next http.Handler) http.Handler {

--- a/internal/middleware/log_test.go
+++ b/internal/middleware/log_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/middleware"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/middleware"
 )
 
 func TestRequestLogger(t *testing.T) {

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -4,7 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"git.maronato.dev/maronato/finger/internal/log"
+	"github.com/Maronato/go-finger/internal/log"
 )
 
 func Recoverer(next http.Handler) http.Handler {

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/middleware"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/middleware"
 )
 
 func assertNoPanic(t *testing.T, f func()) {

--- a/internal/middleware/wrapper_test.go
+++ b/internal/middleware/wrapper_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/middleware"
+	"github.com/Maronato/go-finger/internal/middleware"
 )
 
 func TestWrapResponseWriter(t *testing.T) {

--- a/internal/server/healthcheck.go
+++ b/internal/server/healthcheck.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"git.maronato.dev/maronato/finger/internal/config"
+	"github.com/Maronato/go-finger/internal/config"
 )
 
 func HealthCheckHandler(_ *config.Config) http.Handler {

--- a/internal/server/healthcheck_test.go
+++ b/internal/server/healthcheck_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/server"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/server"
 )
 
 func TestHealthcheckHandler(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"time"
 
-	"git.maronato.dev/maronato/finger/handler"
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/middleware"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/handler"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/middleware"
+	"github.com/Maronato/go-finger/webfingers"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"git.maronato.dev/maronato/finger/internal/config"
-	"git.maronato.dev/maronato/finger/internal/log"
-	"git.maronato.dev/maronato/finger/internal/server"
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/internal/config"
+	"github.com/Maronato/go-finger/internal/log"
+	"github.com/Maronato/go-finger/internal/server"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func getPortGenerator() func() int {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"git.maronato.dev/maronato/finger/cmd"
+	"github.com/Maronato/go-finger/cmd"
 )
 
 // Version of the app.

--- a/webfingers/webfingers_test.go
+++ b/webfingers/webfingers_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"git.maronato.dev/maronato/finger/webfingers"
+	"github.com/Maronato/go-finger/webfingers"
 )
 
 func TestNewWebFingers(t *testing.T) {


### PR DESCRIPTION
Closes #2 and cherry-picks the workflow fixes from @ArtemStepanov and adds the remaining changes needed to fully migrate the project to GitHub.

## Changes

**From PR #2 (by @ArtemStepanov):**
- Switch Docker registry login to use `secrets.GITHUB_TOKEN` with GHCR
- Add `workflow_dispatch` trigger to the release workflow for manual runs

**Additional fixes:**
- Update all GitHub Actions to latest versions (`actions/checkout@v4`, `docker/setup-buildx-action@v3`, etc.)
- Remove redundant Go build cache from `actions/cache` (Docker BuildKit handles this internally)
- Migrate module path from `git.maronato.dev/maronato/go-finger` to `<github.com/Maronato/go-finger`> across all 22 Go source files and `go.mod`
- Update README import examples and documentation references to the new module path
